### PR TITLE
Rails 3.2 + deprecation warnings

### DIFF
--- a/lib/slugged/caching.rb
+++ b/lib/slugged/caching.rb
@@ -15,28 +15,25 @@ module Slugged
       after_save :globally_cache_slug
     end
    
-    module InstanceMethods
-      # Automatically called in after_save, will cache this records id
-      # with to match the current records slug / scope
-      def globally_cache_slug
-        return unless send(:"#{self.cached_slug_column}_changed?")
-        value = self.to_slug
-        self.class.cache_slug_lookup!(value, self) if value.present?
-        unless use_slug_history
-          value = send(:"#{self.cached_slug_column}_was")
-          self.class.cache_slug_lookup!(value, nil)
-        end
+    # Automatically called in after_save, will cache this records id
+    # with to match the current records slug / scope
+    def globally_cache_slug
+      return unless send(:"#{self.cached_slug_column}_changed?")
+      value = self.to_slug
+      self.class.cache_slug_lookup!(value, self) if value.present?
+      unless use_slug_history
+        value = send(:"#{self.cached_slug_column}_was")
+        self.class.cache_slug_lookup!(value, nil)
       end
-      
-      # Wraps remove_slug_history! to remove each of the slugs
-      # recording in this models slug history.
-      def remove_slug_history!
-        previous_slugs.each { |s| self.class.cache_slug_lookup!(s, nil) }
-        super
-      end
-      
     end
-   
+    
+    # Wraps remove_slug_history! to remove each of the slugs
+    # recording in this models slug history.
+    def remove_slug_history!
+      previous_slugs.each { |s| self.class.cache_slug_lookup!(s, nil) }
+      super
+    end
+
     module ClassMethods
       
       # Wraps find_using_slug to look in the cache.

--- a/lib/slugged/slug.rb
+++ b/lib/slugged/slug.rb
@@ -1,6 +1,6 @@
 module Slugged
   class Slug < ActiveRecord::Base
-    set_table_name "slugs"
+    self.table_name "slugs"
   
     validates_presence_of :record_id, :slug, :scope
   

--- a/lib/slugged/slug.rb
+++ b/lib/slugged/slug.rb
@@ -1,6 +1,6 @@
 module Slugged
   class Slug < ActiveRecord::Base
-    self.table_name "slugs"
+    self.table_name = "slugs"
   
     validates_presence_of :record_id, :slug, :scope
   

--- a/lib/slugged/slug_history.rb
+++ b/lib/slugged/slug_history.rb
@@ -6,26 +6,22 @@ module Slugged
       after_save :record_slug_changes
       after_destroy :remove_slug_history!
     end
-   
-    module InstanceMethods
-      
-      def previous_slugs
-        Slugged.previous_slugs_for(self)
-      end
-      
-      def remove_slug_history!
-        Slugged.remove_slug_history_for(self)
-      end
-      
-      protected
-      
-      def record_slug_changes
-        slug_column = self.cached_slug_column
-        return unless send(:"#{slug_column}_changed?")
-        value = send(:"#{slug_column}_was")
-        Slugged.record_slug(self, value) if value.present?
-      end
-      
+
+    def previous_slugs
+      Slugged.previous_slugs_for(self)
+    end
+    
+    def remove_slug_history!
+      Slugged.remove_slug_history_for(self)
+    end
+    
+    protected
+    
+    def record_slug_changes
+      slug_column = self.cached_slug_column
+      return unless send(:"#{slug_column}_changed?")
+      value = send(:"#{slug_column}_was")
+      Slugged.record_slug(self, value) if value.present?
     end
     
     module ClassMethods


### PR DESCRIPTION
I've removed the deprecation warnings from my app, it was really just set_table_name + no longer needed InstanceMethods module for ActiveSupport::Concern

<3
