### PR TITLE
Rails 3.2 optimisations using `#pluck`.

### DIFF
--- a/lib/slugged/slug.rb
+++ b/lib/slugged/slug.rb
@@ -9,8 +9,22 @@ module Slugged
     scope :for_record, lambda { |r| where(:record_id => r.id, :scope => Slugged.key_for_scope(r)) }
     scope :for_slug,   lambda { |scope, slug| where(:scope=> scope.to_s, :slug => slug.to_s)}
   
-    def self.id_for(scope, slug)
-      ordered.for_slug(scope, slug).first.try(:record_id)
+    if methods.include? :pluck
+      def self.id_for(scope, slug)
+        ordered.for_slug(scope, slug).pluck(:record_id).first
+      end
+      
+      def self.previous_for(record)
+        ordered.only_slug.for_record(record).pluck(:slug)
+      end
+    else
+      def self.id_for(scope, slug)
+        ordered.for_slug(scope, slug).first.try(:record_id)
+      end
+    
+      def self.previous_for(record)
+        ordered.only_slug.for_record(record).all.map(&:slug)
+      end
     end
     
     def self.record_slug(record, slug)
@@ -18,10 +32,6 @@ module Slugged
       # Clear slug history in this scope before recording the new slug
       for_slug(scope, slug).delete_all
       create :scope => scope, :record_id => record.id, :slug => slug.to_s
-    end
-    
-    def self.previous_for(record)
-      ordered.only_slug.for_record(record).all.map(&:slug)
     end
     
     def self.remove_history_for(record)


### PR DESCRIPTION
Optimise a couple of common slugged model methods to use `#pluck` if available to avoid the instaciation rigmarole.

P.S. You should get slugged testing on travis so you can multiplex for 3.0, 3.1 and 3.2! :D
