### PR TITLE
Make it work with Rails 4 and Ruby 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Allow testing multiple versions with Travis.
 rails_version = ENV['RAILS_VERSION']

--- a/lib/slugged/active_record_methods.rb
+++ b/lib/slugged/active_record_methods.rb
@@ -85,7 +85,7 @@ module Slugged
       end
       
       def slug_scope_relation(record)
-        has_slug_scope? ? where(slug_scope => record.send(slug_scope)) : scoped
+        has_slug_scope? ? where(slug_scope => record.send(slug_scope)) : where(nil)
       end
       
       def slug_value_for(value)

--- a/lib/slugged/caching.rb
+++ b/lib/slugged/caching.rb
@@ -37,10 +37,10 @@ module Slugged
     module ClassMethods
       
       # Wraps find_using_slug to look in the cache.
-      def find_using_slug(slug, options = {})
+      def find_using_slug(slug)
         # First, attempt to load an id and then record from the cache.
         if (cached_id = lookup_cached_id_from_slug(slug)).present?
-          return find(cached_id, options).tap { |r| r.found_via_slug = slug }
+          return find(cached_id).tap { |r| r.found_via_slug = slug }
         end
         # Otherwise, fallback to the normal approach.
         super.tap do |record|

--- a/lib/slugged/finders.rb
+++ b/lib/slugged/finders.rb
@@ -1,18 +1,18 @@
 module Slugged
   module Finders
     
-    def find_using_slug(slug, options = {})
+    def find_using_slug(slug)
       slug = slug.to_s
       value = nil
-      value ||= find_by_id(slug.to_i, options) if slug =~ /\A\d+\Z/
-      value ||= with_cached_slug(slug).first(options)
-      value ||= find_using_slug_history(slug, options) if use_slug_history
+      value ||= find_by_id(slug.to_i) if slug =~ /\A\d+\Z/
+      value ||= with_cached_slug(slug).first
+      value ||= find_using_slug_history(slug) if use_slug_history
       value.found_via_slug = slug if value.present?
       value
     end
     
-    def find_using_slug!(slug, options = {})
-      find_using_slug(slug, options) or raise ActiveRecord::RecordNotFound
+    def find_using_slug!(slug)
+      find_using_slug(slug) or raise ActiveRecord::RecordNotFound
     end
     
   end

--- a/lib/slugged/scopes.rb
+++ b/lib/slugged/scopes.rb
@@ -6,7 +6,7 @@ module Slugged
     end
     
     def other_than(record)
-      record.new_record? ? scoped : where("#{quoted_table_name}.#{connection.quote_column_name(:id)} != ?", record.id)
+      record.new_record? ? where(nil) : where("#{quoted_table_name}.#{connection.quote_column_name(:id)} != ?", record.id)
     end
     
   end

--- a/lib/slugged/slug.rb
+++ b/lib/slugged/slug.rb
@@ -4,8 +4,8 @@ module Slugged
   
     validates_presence_of :record_id, :slug, :scope
   
-    scope :ordered,    order('created_at DESC')
-    scope :only_slug,  select(:slug)
+    scope :ordered,    lambda { order('created_at DESC') }
+    scope :only_slug,  lambda { select(:slug) }
     scope :for_record, lambda { |r| where(:record_id => r.id, :scope => Slugged.key_for_scope(r)) }
     scope :for_slug,   lambda { |scope, slug| where(:scope=> scope.to_s, :slug => slug.to_s)}
   

--- a/lib/slugged/slug_history.rb
+++ b/lib/slugged/slug_history.rb
@@ -26,9 +26,9 @@ module Slugged
     
     module ClassMethods
       
-      def find_using_slug_history(slug, options = {})
+      def find_using_slug_history(slug)
         id = Slugged.last_known_slug_id(self, slug)
-        id.present? ? find_by_id(id, options) : nil
+        id.present? ? find_by_id(id) : nil
       end
       
     end

--- a/slugged.gemspec
+++ b/slugged.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.rdoc_options              = ["--charset=UTF-8"]
   s.summary                   = %q{Super simple slugs for ActiveRecord 3.0 and higher, with support for slug history}
 
-  s.add_runtime_dependency "activerecord",  "~> 3.0"
-  s.add_runtime_dependency "activesupport", "~> 3.0"
+  s.add_runtime_dependency "activerecord",  ">= 3.0"
+  s.add_runtime_dependency "activesupport", ">= 3.0"
   s.add_runtime_dependency "uuid"
 
   s.add_development_dependency "shoulda"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,13 +28,13 @@ class Test::Unit::TestCase
     User.is_sluggable field, options
   end
   
-  def assert_same_as_slug(user, slug, options = {})
-    found_user = User.find_using_slug(slug, options)
+  def assert_same_as_slug(user, slug)
+    found_user = User.find_using_slug(slug)
     assert_equal user, found_user, "#{slug.inspect} should return #{user.inspect}, got #{found_user.inspect}"
   end
   
-  def assert_different_to_slug(user, slug, options = {})
-    found_user = User.find_using_slug(slug, options)
+  def assert_different_to_slug(user, slug)
+    found_user = User.find_using_slug(slug)
     assert_not_equal user, found_user, "#{slug.inspect} should not return #{user.inspect}, got same record."
   end
   

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,5 @@
-$KCODE = 'UTF8'
+# encoding: utf-8
+$KCODE = 'UTF8' if RUBY_VERSION < '1.9'
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
Thank you for writing this gem, it's my favorite for the job and would like to keep using it now that Rails 4 is out.

There aren't any significant changes except in the last commit, where I removed the `options`.  It doesn't seem to be an easy way to preserve this functionality, you can see how Rails 4 implements it here https://github.com/rails/activerecord-deprecated_finders/blob/master/lib/active_record/deprecated_finders/relation.rb#L12   I love `slugged` because its simplicity and this makes it even simpler.  In addition, there are no tests that use this argument, so nothing breaks.
